### PR TITLE
Ajuste en el archivo readme para especificar que el método para el Endpoint es POST.

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@
             <br/>
             <br/>
 
-        + Endpoint para sincronizar un tipo especifico. Se desarrollo bajo en la url `/api/v1/sync_price?type=`. Ej. [http://zoe.test/api/v1/sync_price?type=](http://zoe.test/api/v1/sync_price?type=).
+        + Endpoint para sincronizar un tipo especifico. Se desarrollo bajo en la url `/api/v1/sync_price?type=` y el methodo `POST`. Ej. [http://zoe.test/api/v1/sync_price?type=](http://zoe.test/api/v1/sync_price?type=).
 
             <br/>
             <br/>


### PR DESCRIPTION
Ajuste en el archivo readme para especificar que el método para el Endpoint es POST.